### PR TITLE
Fix interfile import statements. 

### DIFF
--- a/code/folder/another_file.py
+++ b/code/folder/another_file.py
@@ -1,5 +1,5 @@
 
-from code.another_folder.dangerous_sink import dangerous_sink
+from another_folder.dangerous_sink import dangerous_sink
 
 def do_something(id: int):
     # ruleid: user_input_to_dangerous_sink

--- a/code/main.py
+++ b/code/main.py
@@ -1,5 +1,5 @@
 
-from code.folder.another_file import do_something
+from folder.another_file import do_something
 
 
 def user_input():


### PR DESCRIPTION
The files in the multi-file version of the vulnerability contained faulty import statements. 

They included `code` in the namespace which was not accessible from main.py since main.py is inside of the code directory.

This portion of the namespace is deleted so that main.py can run without error. 